### PR TITLE
removed resultDestination variable as an agrument to `ComparisonImage` object.

### DIFF
--- a/src/main/java/Utilities/CompareImages.java
+++ b/src/main/java/Utilities/CompareImages.java
@@ -15,7 +15,7 @@ public class CompareImages {
 
         File resultDestination = new File("./src/test/resources/result/"+file );
 
-        ImageComparison imageComparison = new ImageComparison( expectedImage, actualImage, resultDestination );
+        ImageComparison imageComparison = new ImageComparison( expectedImage, actualImage );
 
         ImageComparisonResult comparisonResult = imageComparison.compareImages();
 


### PR DESCRIPTION
Hi @dhoanglong91epam,
As far as I understand your logic, you don't need to add resultDestination to `ComparisonImage` constructor because it would trigger saving result in all the cases, even when ImageComparisonState is `MATCH`.

Also, I would recommend you to use comparing enums instead of the Strings.

Best regards,
Roman.